### PR TITLE
Posts have date and are in reverse chronological order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 .byebug_history
 .env
 /coverage/
+/vendor/

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,6 @@
 <% @posts.each do |post| %>
   <p><%= post.message %></p>
+  <p><%= post.updated_at %></p>
 <% end %>
 
 <%= link_to new_post_path do %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
-<% @posts.each do |post| %>
+<% @posts.reverse_each do |post| %>
   <p><%= post.message %></p>
   <p><%= post.updated_at %></p>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <% @posts.reverse_each do |post| %>
-  <p><%= post.message %></p>
+  <p class='message'> <%= post.message %></p>
   <p><%= post.updated_at %></p>
 <% end %>
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe PostsController, type: :controller do
       post :create, params: { post: { message: 'Hello, world!' } }
       expect(Post.find_by(message: 'Hello, world!')).to be
     end
+
+    it 'creates a post with a date' do
+      post :create, params: { post: { message: "Today's date is:"} }
+      expected_result = Post.find_by(message: "Today's date is:").updated_at
+      expect(Time.now - expected_result).to be < 1
+    end
   end
 
   describe 'GET /' do

--- a/spec/features/user_can_submit_posts_spec.rb
+++ b/spec/features/user_can_submit_posts_spec.rb
@@ -10,4 +10,15 @@ RSpec.feature 'Timeline', type: :feature do
     click_button 'Submit'
     expect(page).to have_content('Hello, world!')
   end
+
+  scenario 'Posts are shown in order of creation' do
+    visit '/posts'
+    click_link 'New post'
+    fill_in 'Message', with: 'I am second'
+    click_button 'Submit'
+    click_link 'New post'
+    fill_in 'Message', with: 'I am first'
+    click_button 'Submit'
+    expect(page.all('p')[0]).to have_content 'I am first'
+  end
 end


### PR DESCRIPTION
We made so that the date is shown next to the post. And that the posts are in reverse chronological order. E.g:
- "Great pull request!" - 24/2/2021
- "Nice sweat suit Salar!" - 23/2/2021

Has been tested as well, so run rspec to check it works on yours.

Completed the following tickets in this pull request:
- https://trello.com/c/Su6NPhWS/9-posts-appear-with-newest-post-first-low
- https://trello.com/c/tMWP5BZZ/27-posts-show-the-date-medium
