### PR TITLE
Error messages appear when a user tries to change another user's post

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 class ApplicationController < ActionController::Base
-  # protect_from_forgery with: :exception
+  protect_from_forgery with: :exception
 
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || posts_path
   end
 
-  # before_action :authenticate_user!
+  before_action :authenticate_user!
 
   # def authenticate_user!
   #   if user_signed_in?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  # protect_from_forgery with: :exception
 
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || posts_path
   end
 
-  before_action :authenticate_user!
+  # before_action :authenticate_user!
 
   # def authenticate_user!
   #   if user_signed_in?

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,8 +14,9 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = Post.create(post_params)
-    # @post = current_user.posts.build(post_params)
+    # @post = Post.create(post_params)
+    @post = current_user.posts.build(post_params)
+    @post.save
     redirect_to posts_url
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,12 +1,21 @@
 # frozen_string_literal: true
 
 class PostsController < ApplicationController
+
+  protect_from_forgery with: :exception
+
+  before_action :authenticate_user!
+
+  before_action :correct_user, only: [:edit, :update, :destroy]
+
   def new
-    @post = Post.new
+    # @post = Post.new
+    @post = current_user.posts.build
   end
 
   def create
     @post = Post.create(post_params)
+    # @post = current_user.posts.build(post_params)
     redirect_to posts_url
   end
 
@@ -28,6 +37,11 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     @post.destroy
     redirect_to posts_url
+  end
+
+  def correct_user
+    @post = current_user.posts.find_by(id: params[:id])
+    redirect_to posts_path, notice: "Not authorised!" if @post.nil? 
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,10 +2,6 @@
 
 class PostsController < ApplicationController
 
-  protect_from_forgery with: :exception
-
-  before_action :authenticate_user!
-
   before_action :correct_user, only: [:edit, :update, :destroy]
 
   def new

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,9 +3,9 @@
     <p class='message'> <%= post.message %></p>
     <p class='date'><%= post.updated_at %></p>
     <p class='user-email'><%= User.find_by(id: post.user_id).email %></p>
+    <% if post.user.id == current_user.id %>
     <%= link_to "Edit", edit_post_path(post.id) %>
     <%= link_to "Delete", post_path(post.id), method: :delete, data: { confirm: 'Are you certain you want to delete this post?' } %>
-    <% if post.user.id == current_user %>
     <% end %>
 
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,14 +3,13 @@
     <p class='message'> <%= post.message %></p>
     <p class='date'><%= post.updated_at %></p>
     <p class='user-email'><%= User.find_by(id: post.user_id).email %></p>
-    <% if current_user.id == post.user_id %>
-      <%= link_to "Edit", edit_post_path(post.id) %>
-      <%= link_to "Delete", post_path(post.id), method: :delete, data: { confirm: 'Are you certain you want to delete this post?' } %>
+    <%= link_to "Edit", edit_post_path(post.id) %>
+    <%= link_to "Delete", post_path(post.id), method: :delete, data: { confirm: 'Are you certain you want to delete this post?' } %>
+    <% if post.user.id == current_user %>
     <% end %>
 
   </div>
 <% end %>
-
 
 <%= link_to new_post_path do %>
   New post

--- a/spec/features/user_can_delete_posts_spec.rb
+++ b/spec/features/user_can_delete_posts_spec.rb
@@ -39,5 +39,11 @@ RSpec.feature 'Timeline', type: :feature do
       expect(first('.post')).not_to have_link('Delete')
     end
 
+    scenario "User is warned when trying to edit another's post" do
+      visit '/posts/1/edit'
+      expect(page).to have_current_path('/posts')
+      expect(page).to have_content("Not authorised!")
+    end
+
   end
 end


### PR DESCRIPTION
When one user tries to edit or delete someone's post, they receive an error message saying that you can't do that. 
E.g:
User1@mail.com posts: "Salar's sweatsuit is looking good"
User2@evilmail.com tries to delete the post which results in "Not authorised!"

Completed Tickets:
https://trello.com/c/ngPrAxHo/35-see-a-helpful-error-message-if-they-try-to-update-another-users-post-low
https://trello.com/c/68wbPSnF/37-see-a-helpful-error-message-if-they-try-to-delete-another-users-post-low