### PR TITLE
User profile

### DIFF
--- a/app/assets/stylesheets/posts.css
+++ b/app/assets/stylesheets/posts.css
@@ -14,6 +14,14 @@
   /* border: 0.1em solid #0a122a; */
 }
 
+.username {
+  display:inline-block;
+} 
+
+.date {
+  display:inline-block;margin-right:4px;
+} 
+
 #new-post-link {
   padding: 0.5em;
   padding-top: 1.5em;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,16 @@ class ApplicationController < ActionController::Base
     stored_location_for(resource) || posts_path
   end
 
+  before_action :configure_permitted_parameters, if: :devise_controller?
+  
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [:username])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:username])
+  end
+
   before_action :authenticate_user!
 
   # def authenticate_user!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :posts, dependent: :destroy
-<<<<<<< HEAD
   has_many :likes, dependent: :destroy
-=======
+
 
   validate :validate_username
 
@@ -20,5 +19,4 @@ class User < ApplicationRecord
     errors.add(:username, :already_exists) if User.exists?(username: username)
   end
 
->>>>>>> d81a420... Cannot sign up with same username twice with passing tests and change locales file
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,10 +9,7 @@ class User < ApplicationRecord
 
   validate :validate_username
 
-  validates :username, confirmation: true
-  validates :username, presence: true
-
-  validates :username, format: { with: /^[a-zA-Z0-9_.]*$/, :multiline => true }
+  validates :username, confirmation: true, presence: true, format: { with: /^[a-zA-Z0-9_.]*$/, :multiline => true }
 
   def validate_username
     errors.add(:username, :already_exists) if User.exists?(username: username)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,18 +9,15 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
 =======
 
-
   validate :validate_username
 
   validates :username, confirmation: true
   validates :username, presence: true
 
-  validates_format_of :username, with: /^[a-zA-Z0-9_\.]*$/, :multiline => true
+  validates :username, format: { with: /^[a-zA-Z0-9_.]*$/, :multiline => true }
 
   def validate_username
-    if User.where(username: username).exists?
-      errors.add(:username, :already_exists)
-    end
+    errors.add(:username, :already_exists) if User.exists?(username: username)
   end
 
 >>>>>>> d81a420... Cannot sign up with same username twice with passing tests and change locales file

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,11 +12,14 @@ class User < ApplicationRecord
 
   validate :validate_username
 
+  validates :username, confirmation: true
+  validates :username, presence: true
+
   validates_format_of :username, with: /^[a-zA-Z0-9_\.]*$/, :multiline => true
 
   def validate_username
     if User.where(username: username).exists?
-      errors.add(:username, :already_exists) 
+      errors.add(:username, :already_exists)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,6 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :likes, dependent: :destroy
 
-
   validate :validate_username
 
   validates :username, confirmation: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,20 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :posts, dependent: :destroy
+<<<<<<< HEAD
   has_many :likes, dependent: :destroy
+=======
+
+
+  validate :validate_username
+
+  validates_format_of :username, with: /^[a-zA-Z0-9_\.]*$/, :multiline => true
+
+  def validate_username
+    if User.where(username: username).exists?
+      errors.add(:username, :already_exists) 
+    end
+  end
+
+>>>>>>> d81a420... Cannot sign up with same username twice with passing tests and change locales file
 end

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -7,7 +7,7 @@
   <div class="field">
     <%= f.label :password, "New password" %><br />
     <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <em>(<%= @minimum_password_length %> - 10 characters)</em><br />
     <% end %>
     <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -7,7 +7,7 @@
   <div class="field">
     <%= f.label :password, "New password" %><br />
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> - 10 characters)</em>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
     <% end %>
     <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -17,7 +17,7 @@
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br />
-      <em>(<%= @minimum_password_length %> - 10 characters)</em>
+      <em><%= @minimum_password_length %> characters minimum</em>
     <% end %>
   </div>
 
@@ -38,6 +38,6 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure? All your posts will be deleted!" }, method: :delete %></p>
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
 
 <%= link_to "Back", :back %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -22,7 +22,7 @@
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <em><%= @minimum_password_length %> - 10 characters</em>
     <% end %>
   </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,6 +38,6 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure? All your posts will be deleted!" }, method: :delete %></p>
 
 <%= link_to "Back", :back %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -13,6 +13,11 @@
   <% end %>
 
   <div class="field">
+  <%= f.label :username %><br />
+  <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
+  </div>
+
+  <div class="field">
     <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -16,7 +16,7 @@
   <div class="field">
     <%= f.label :password %>
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <em>(<%= @minimum_password_length %> - 10 characters)</em>
     <% end %><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
   </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -13,7 +13,6 @@
     <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
   </div>
 
-
   <div class="field">
     <%= f.label :password %>
     <% if @minimum_password_length %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,9 +9,15 @@
   </div>
 
   <div class="field">
+    <%= f.label :username %><br />
+    <%= f.text_field :username, autofocus: true, autocomplete: "username" %>
+  </div>
+
+
+  <div class="field">
     <%= f.label :password %>
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> - 10 characters)</em>
+    <em>(<%= @minimum_password_length %> characters minimum)</em>
     <% end %><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,10 +7,15 @@
 <% @posts.reverse_each do |post| %>
 
   <div class='post'>
+<<<<<<< HEAD
     <p class='message'><%= h(post.message).gsub(/\n/, '<br/>').html_safe %> </p>
     <p class='date'>Posted at <%= post.updated_at.strftime("%k:%M on %d/%m/%Y") %></p>
     <p class='username'><%= User.find_by(id: post.user_id).username %></p>
     <p class='user-email'><%= User.find_by(id: post.user_id).email %></p>
+=======
+    <p class='message'> <%= post.message %></p>
+    <p class='date'>Posted at <%= post.updated_at.strftime("%k:%M on %d/%m/%Y") %> by <p class='username'><%= User.find_by(id: post.user_id).username %></p></p>
+>>>>>>> 44a34b1... Username now shows rather than email
     <% if post.user.id == current_user.id %>
       <% if Time.zone.now - post.created_at < (60 * 10) %>
         <%= link_to "Edit", edit_post_path(post.id) %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,6 +9,7 @@
   <div class='post'>
     <p class='message'><%= h(post.message).gsub(/\n/, '<br/>').html_safe %> </p>
     <p class='date'>Posted at <%= post.updated_at.strftime("%k:%M on %d/%m/%Y") %></p>
+    <p class='username'><%= User.find_by(id: post.user_id).username %></p>
     <p class='user-email'><%= User.find_by(id: post.user_id).email %></p>
     <% if post.user.id == current_user.id %>
       <% if Time.zone.now - post.created_at < (60 * 10) %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -7,15 +7,8 @@
 <% @posts.reverse_each do |post| %>
 
   <div class='post'>
-<<<<<<< HEAD
     <p class='message'><%= h(post.message).gsub(/\n/, '<br/>').html_safe %> </p>
-    <p class='date'>Posted at <%= post.updated_at.strftime("%k:%M on %d/%m/%Y") %></p>
-    <p class='username'><%= User.find_by(id: post.user_id).username %></p>
-    <p class='user-email'><%= User.find_by(id: post.user_id).email %></p>
-=======
-    <p class='message'> <%= post.message %></p>
     <p class='date'>Posted at <%= post.updated_at.strftime("%k:%M on %d/%m/%Y") %> by <p class='username'><%= User.find_by(id: post.user_id).username %></p></p>
->>>>>>> 44a34b1... Username now shows rather than email
     <% if post.user.id == current_user.id %>
       <% if Time.zone.now - post.created_at < (60 * 10) %>
         <%= link_to "Edit", edit_post_path(post.id) %>

--- a/app/views/welcome/_header.html.erb
+++ b/app/views/welcome/_header.html.erb
@@ -20,7 +20,7 @@
           <%= link_to "Sign out", destroy_user_session_path, class:"nav-link", method: :delete %>
         </li>
         <li class="nav-item">
-          <%= link_to "Profile", edit_user_registration_path, class:"nav-link" %>
+          <%= link_to "Settings", edit_user_registration_path, class:"nav-link" %>
         </li>
 
       </ul>

--- a/app/views/welcome/_header.html.erb
+++ b/app/views/welcome/_header.html.erb
@@ -4,7 +4,7 @@
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    
+
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
          <li class="nav-item">
@@ -18,6 +18,9 @@
         </li>
          <li class="nav-item">
           <%= link_to "Sign out", destroy_user_session_path, class:"nav-link", method: :delete %>
+        </li>
+        <li class="nav-item">
+          <%= link_to "Profile", edit_user_registration_path, class:"nav-link" %>
         </li>
 
       </ul>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -55,6 +55,7 @@ en:
       unlocked: "Your account has been unlocked successfully. Please sign in to continue."
   errors:
     messages:
+      already_exists: "already exists!"
       already_confirmed: "was already confirmed, please try signing in"
       confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
       expired: "has expired, please request a new one"

--- a/db/migrate/20210302153120_add_username_to_users.rb
+++ b/db/migrate/20210302153120_add_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddUsernameToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :username, :string
+    add_index :users, :username, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< HEAD
-ActiveRecord::Schema.define(version: 20210302121331) do
-=======
 ActiveRecord::Schema.define(version: 20210302153120) do
->>>>>>> d0ad684... User name has been added to posts
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< HEAD
 ActiveRecord::Schema.define(version: 20210302121331) do
+=======
+ActiveRecord::Schema.define(version: 20210302153120) do
+>>>>>>> d0ad684... User name has been added to posts
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,8 +44,10 @@ ActiveRecord::Schema.define(version: 20210302121331) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "likes", "posts"

--- a/spec/features/date_last_modified_shown_by_post_spec.rb
+++ b/spec/features/date_last_modified_shown_by_post_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'Submitted posts should show date and time' do
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     expect(Time.zone.now - first('.date').text.to_datetime).to be < 60
   end

--- a/spec/features/date_last_modified_shown_by_post_spec.rb
+++ b/spec/features/date_last_modified_shown_by_post_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'Submitted posts should show date and time' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     expect(Time.zone.now - first('.date').text.to_datetime).to be < 60
   end

--- a/spec/features/liking_posts_spec.rb
+++ b/spec/features/liking_posts_spec.rb
@@ -1,7 +1,7 @@
 feature 'liking posts' do
 
   before do
-    sign_up(email: 'test@test.com', password: 'password')
+    sign_up(email: 'test@test.com', username: 'Troy', password: 'password')
     create_a_new_post_and_see_it_on_the_feed('Great post')
   end
 

--- a/spec/features/posts_edit_button_times_out_spec.rb
+++ b/spec/features/posts_edit_button_times_out_spec.rb
@@ -3,7 +3,7 @@ require 'active_support/testing/time_helpers'
 RSpec.feature 'Timeline', type: :feature do
   include ActiveSupport::Testing::TimeHelpers
   scenario 'Submitted posts edit button should not show after 10 minutes' do
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')    
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')    
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     travel 11.minutes
     visit '/posts'
@@ -12,7 +12,7 @@ RSpec.feature 'Timeline', type: :feature do
 
   context 'User does not refresh page when creating initial post' do
     scenario 'User cannot reach edit page' do
-      sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+      sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
       create_a_new_post_and_see_it_on_the_feed("Hello, world!")
       travel 11.minutes
       click_link "Edit"

--- a/spec/features/posts_edit_button_times_out_spec.rb
+++ b/spec/features/posts_edit_button_times_out_spec.rb
@@ -3,7 +3,7 @@ require 'active_support/testing/time_helpers'
 RSpec.feature 'Timeline', type: :feature do
   include ActiveSupport::Testing::TimeHelpers
   scenario 'Submitted posts edit button should not show after 10 minutes' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')    
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     travel 11.minutes
     visit '/posts'
@@ -12,7 +12,7 @@ RSpec.feature 'Timeline', type: :feature do
 
   context 'User does not refresh page when creating initial post' do
     scenario 'User cannot reach edit page' do
-      sign_up(email: 'test@email.com', password: 'testpass')
+      sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
       create_a_new_post_and_see_it_on_the_feed("Hello, world!")
       travel 11.minutes
       click_link "Edit"

--- a/spec/features/user_can_delete_posts_spec.rb
+++ b/spec/features/user_can_delete_posts_spec.rb
@@ -2,30 +2,38 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'User can delete a former post' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')    
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     first('.post').click_link 'Delete'
     expect(page).not_to have_content('Hello, world!')
   end
 
   context 'when someone else has made a post' do
-    before do
-      sign_up(email: 'user1@email.com', password: 'testpass')
-      create_a_new_post_and_see_it_on_the_feed("Hello, world!")
-      click_link 'Sign out'
-      sign_up(email: 'user2@email.com', password: 'testpass')
-      visit '/posts'
-    end
 
     scenario 'User can not see edit on others post' do
+      sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+      create_a_new_post_and_see_it_on_the_feed("Hello, world!")
+      click_link 'Sign out'
+      sign_up(email: 'user2@email.com', username:'Troy2', password: 'testpass')
+      visit '/posts'
       expect(first('.post')).not_to have_link('Edit')
     end
 
     scenario 'User can not see delete on others post' do
+      sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+      create_a_new_post_and_see_it_on_the_feed("Hello, world!")
+      click_link 'Sign out'
+      sign_up(email: 'user2@email.com', username:'Troy2', password: 'testpass')
+      visit '/posts'
       expect(first('.post')).not_to have_link('Delete')
     end
 
     scenario "User is warned when trying to edit another's post" do
+      sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+      create_a_new_post_and_see_it_on_the_feed("Hello, world!")
+      click_link 'Sign out'
+      sign_up(email: 'test@email2.com', username:'Troy2', password: 'testpass')
+      visit '/posts'
       visit '/posts/1/edit'
       expect(page).to have_current_path('/posts')
       expect(page).to have_content("Not authorised!")

--- a/spec/features/user_can_delete_posts_spec.rb
+++ b/spec/features/user_can_delete_posts_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'User can delete a former post' do
-    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')    
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     first('.post').click_link 'Delete'
     expect(page).not_to have_content('Hello, world!')
@@ -10,30 +10,23 @@ RSpec.feature 'Timeline', type: :feature do
 
   context 'when someone else has made a post' do
 
-    scenario 'User can not see edit on others post' do
+    before do
       sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
       create_a_new_post_and_see_it_on_the_feed("Hello, world!")
       click_link 'Sign out'
       sign_up(email: 'user2@email.com', username: 'Troy2', password: 'testpass')
       visit '/posts'
+    end
+
+    scenario 'User can not see edit on others post' do
       expect(first('.post')).not_to have_link('Edit')
     end
 
     scenario 'User can not see delete on others post' do
-      sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
-      create_a_new_post_and_see_it_on_the_feed("Hello, world!")
-      click_link 'Sign out'
-      sign_up(email: 'user2@email.com', username: 'Troy2', password: 'testpass')
-      visit '/posts'
       expect(first('.post')).not_to have_link('Delete')
     end
 
     scenario "User is warned when trying to edit another's post" do
-      sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
-      create_a_new_post_and_see_it_on_the_feed("Hello, world!")
-      click_link 'Sign out'
-      sign_up(email: 'test@email2.com', username: 'Troy2', password: 'testpass')
-      visit '/posts'
       visit '/posts/1/edit'
       expect(page).to have_current_path('/posts')
       expect(page).to have_content("Not authorised!")

--- a/spec/features/user_can_delete_posts_spec.rb
+++ b/spec/features/user_can_delete_posts_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'User can delete a former post' do
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')    
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')    
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     first('.post').click_link 'Delete'
     expect(page).not_to have_content('Hello, world!')
@@ -11,28 +11,28 @@ RSpec.feature 'Timeline', type: :feature do
   context 'when someone else has made a post' do
 
     scenario 'User can not see edit on others post' do
-      sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+      sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
       create_a_new_post_and_see_it_on_the_feed("Hello, world!")
       click_link 'Sign out'
-      sign_up(email: 'user2@email.com', username:'Troy2', password: 'testpass')
+      sign_up(email: 'user2@email.com', username: 'Troy2', password: 'testpass')
       visit '/posts'
       expect(first('.post')).not_to have_link('Edit')
     end
 
     scenario 'User can not see delete on others post' do
-      sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+      sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
       create_a_new_post_and_see_it_on_the_feed("Hello, world!")
       click_link 'Sign out'
-      sign_up(email: 'user2@email.com', username:'Troy2', password: 'testpass')
+      sign_up(email: 'user2@email.com', username: 'Troy2', password: 'testpass')
       visit '/posts'
       expect(first('.post')).not_to have_link('Delete')
     end
 
     scenario "User is warned when trying to edit another's post" do
-      sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+      sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
       create_a_new_post_and_see_it_on_the_feed("Hello, world!")
       click_link 'Sign out'
-      sign_up(email: 'test@email2.com', username:'Troy2', password: 'testpass')
+      sign_up(email: 'test@email2.com', username: 'Troy2', password: 'testpass')
       visit '/posts'
       visit '/posts/1/edit'
       expect(page).to have_current_path('/posts')

--- a/spec/features/user_can_edit_posts_spec.rb
+++ b/spec/features/user_can_edit_posts_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'User can update a former post to display a new message' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     first('.post').click_link 'Edit'
     fill_in 'Message', with: 'I am updated!'

--- a/spec/features/user_can_edit_posts_spec.rb
+++ b/spec/features/user_can_edit_posts_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'User can update a former post to display a new message' do
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     first('.post').click_link 'Edit'
     fill_in 'Message', with: 'I am updated!'

--- a/spec/features/user_can_have_line_breaks_spec.rb
+++ b/spec/features/user_can_have_line_breaks_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.feature 'Timeline', type: :feature do
   scenario 'User can have line breaks in their message' do
     Capybara.current_driver = :selenium_chrome_headless
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!\n This is great!")
     # This should be changed to match the <br> usage
     expect(page).to have_content("Hello, world!\n This is great!")

--- a/spec/features/user_can_submit_posts_spec.rb
+++ b/spec/features/user_can_submit_posts_spec.rb
@@ -2,12 +2,12 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'Can submit posts and view them' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
   end
 
   scenario 'Posts are shown in order of creation' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     create_a_new_post_and_see_it_on_the_feed("I am first")
     expect(page.all('.post')[0]).to have_content 'I am first'

--- a/spec/features/user_can_submit_posts_spec.rb
+++ b/spec/features/user_can_submit_posts_spec.rb
@@ -2,12 +2,12 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'Can submit posts and view them' do
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
   end
 
   scenario 'Posts are shown in order of creation' do
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     create_a_new_post_and_see_it_on_the_feed("I am first")
     expect(page.all('.post')[0]).to have_content 'I am first'

--- a/spec/features/user_is_shown_with_post_spec.rb
+++ b/spec/features/user_is_shown_with_post_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'Submitted posts should show user' do
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     expect(page).to have_content "Troy"
   end

--- a/spec/features/user_is_shown_with_post_spec.rb
+++ b/spec/features/user_is_shown_with_post_spec.rb
@@ -4,6 +4,6 @@ RSpec.feature 'Timeline', type: :feature do
   scenario 'Submitted posts should show user' do
     sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
-    expect(page).to have_content "test@email.com"
+    expect(page).to have_content "Troy"
   end
 end

--- a/spec/features/user_is_shown_with_post_spec.rb
+++ b/spec/features/user_is_shown_with_post_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.feature 'Timeline', type: :feature do
   scenario 'Submitted posts should show user' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello, world!")
     expect(page).to have_content "test@email.com"
   end

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -2,17 +2,17 @@ require 'rails_helper'
 
 RSpec.feature 'User Profle', type: :feature do
   scenario 'User can visit their own Profile page' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
     click_link "Profile"
     expect(page).to have_current_path('/users/edit')
   end
 
   scenario 'User can delete their own Profile' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello world!")
     click_link "Profile"
     click_button "Cancel my account"
-    sign_up(email: 'test2@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
     expect(page).not_to have_content("Hello world!")
   end 
 

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -2,18 +2,18 @@ require 'rails_helper'
 
 RSpec.feature 'User Profle', type: :feature do
   scenario 'User can visit their own Profile page' do
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     click_link "Profile"
     expect(page).to have_current_path('/users/edit')
   end
 
   scenario 'User can delete their own Profile' do
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello world!")
     click_link "Profile"
     click_button "Cancel my account"
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+    sign_up(email: 'test2@email.com', username: 'Troy', password: 'testpass')
     expect(page).not_to have_content("Hello world!")
-  end 
+  end
 
 end

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature 'User Profle', type: :feature do
+  scenario 'User can visit their own Profile page' do
+    sign_up(email: 'test@email.com', password: 'testpass')
+    click_link "Profile"
+    expect(page).to have_current_path('/users/edit')
+  end
+
+  scenario 'User can delete their own Profile' do
+    sign_up(email: 'test@email.com', password: 'testpass')
+    create_a_new_post_and_see_it_on_the_feed("Hello world!")
+    click_link "Profile"
+    click_button "Cancel my account"
+    sign_up(email: 'test2@email.com', password: 'testpass')
+    expect(page).not_to have_content("Hello world!")
+  end 
+
+end

--- a/spec/features/user_settings_spec.rb
+++ b/spec/features/user_settings_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 RSpec.feature 'User settings', type: :feature do
   scenario 'User can visit the settings page' do
     sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')

--- a/spec/features/user_settings_spec.rb
+++ b/spec/features/user_settings_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
-RSpec.feature 'User Profle', type: :feature do
-  scenario 'User can visit their own Profile page' do
+RSpec.feature 'User settings', type: :feature do
+  scenario 'User can visit the settings page' do
     sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
-    click_link "Profile"
+    click_link "Settings"
     expect(page).to have_current_path('/users/edit')
   end
 
   scenario 'User can delete their own Profile' do
     sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("Hello world!")
-    click_link "Profile"
+    click_link "Settings"
     click_button "Cancel my account"
     sign_up(email: 'test2@email.com', username: 'Troy', password: 'testpass')
     expect(page).not_to have_content("Hello world!")

--- a/spec/features/username_invalid_spec.rb
+++ b/spec/features/username_invalid_spec.rb
@@ -1,0 +1,8 @@
+RSpec.feature 'Username', type: :feature do
+  scenario 'User cannot sign up with a username that already exists' do
+    sign_up(email: 'test@email.com', username: "Troy", password: 'testpass')
+    click_link "Sign out"
+    sign_up(email: 'test2@email.com', username: "Troy", password: 'testpass')
+    expect(page).to have_content('Username already exists!')
+  end
+end

--- a/spec/features/username_invalid_spec.rb
+++ b/spec/features/username_invalid_spec.rb
@@ -5,4 +5,14 @@ RSpec.feature 'Username', type: :feature do
     sign_up(email: 'test2@email.com', username: "Troy", password: 'testpass')
     expect(page).to have_content('Username already exists!')
   end
+
+  scenario 'User cannot sign up with a blank username' do
+    sign_up(email: 'test@email.com', username: "", password: 'testpass')
+    expect(page).to have_content("Username can't be blank")
+  end
+
+  scenario 'User cannot sign up with an invaild username' do
+    sign_up(email: 'test@email.com', username: "@", password: 'testpass')
+    expect(page).to have_content("Username is invalid")
+  end
 end

--- a/spec/features/users_can_enter_details_spec.rb
+++ b/spec/features/users_can_enter_details_spec.rb
@@ -1,12 +1,12 @@
 feature 'sign up page' do
   scenario 'user can enter email and password to sign up' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
     expect(page).to have_content('Welcome! You have signed up successfully.')
   end
 
   scenario 'cannot sign up with invalid email' do
     Capybara.current_driver = :selenium_chrome_headless
-    sign_up(email: 'test', password: 'testpass')
+    sign_up(email: 'test', username:'Troy', password: 'testpass')
     expect(page).to have_current_path("/users/sign_up")
   end
 
@@ -14,14 +14,14 @@ feature 'sign up page' do
 
   context 'when password is too short' do
     scenario 'user cannot sign up and is warned' do
-      sign_up(email: 'test@email.com', password: 'short')
+      sign_up(email: 'test@email.com', username:'Troy', password: 'short')
       expect(page).to have_content('Password is too short')
     end
   end
 
   context 'when password is too long' do
     scenario 'user cannot sign up and is warned' do
-      sign_up(email: 'test@email.com', password: 'longpassword')
+      sign_up(email: 'test@email.com', username:'Troy', password: 'long password')
       expect(page).to have_content('Password is too long')
     end
   end
@@ -30,7 +30,7 @@ feature 'sign up page' do
     scenario 'user is redirected to the home page' do
       visit('/')
       click_link('Sign out')
-      sign_up(email: 'test@email.com', password: 'testpass')
+      sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
       expect(page).to have_current_path('/')
     end
   end

--- a/spec/features/users_can_enter_details_spec.rb
+++ b/spec/features/users_can_enter_details_spec.rb
@@ -1,12 +1,12 @@
 feature 'sign up page' do
   scenario 'user can enter email and password to sign up' do
-    sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     expect(page).to have_content('Welcome! You have signed up successfully.')
   end
 
   scenario 'cannot sign up with invalid email' do
     Capybara.current_driver = :selenium_chrome_headless
-    sign_up(email: 'test', username:'Troy', password: 'testpass')
+    sign_up(email: 'test', username: 'Troy', password: 'testpass')
     expect(page).to have_current_path("/users/sign_up")
   end
 
@@ -14,14 +14,14 @@ feature 'sign up page' do
 
   context 'when password is too short' do
     scenario 'user cannot sign up and is warned' do
-      sign_up(email: 'test@email.com', username:'Troy', password: 'short')
+      sign_up(email: 'test@email.com', username: 'Troy', password: 'short')
       expect(page).to have_content('Password is too short')
     end
   end
 
   context 'when password is too long' do
     scenario 'user cannot sign up and is warned' do
-      sign_up(email: 'test@email.com', username:'Troy', password: 'long password')
+      sign_up(email: 'test@email.com', username: 'Troy', password: 'long password')
       expect(page).to have_content('Password is too long')
     end
   end
@@ -30,7 +30,7 @@ feature 'sign up page' do
     scenario 'user is redirected to the home page' do
       visit('/')
       click_link('Sign out')
-      sign_up(email: 'test@email.com', username:'Troy', password: 'testpass')
+      sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
       expect(page).to have_current_path('/')
     end
   end

--- a/spec/features/users_cannot_send_empty_post_spec.rb
+++ b/spec/features/users_cannot_send_empty_post_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Users', type: :feature do
   scenario 'should not be able to send empty posts' do
-    sign_up(email: 'test@email.com', password: 'testpass')
+    sign_up(email: 'test@email.com', username: 'Troy', password: 'testpass')
     create_a_new_post_and_see_it_on_the_feed("")
     expect(page).to have_content("Cannot post an empty message!")
   end

--- a/spec/helpers/web_helper.rb
+++ b/spec/helpers/web_helper.rb
@@ -6,9 +6,10 @@ def create_a_new_post_and_see_it_on_the_feed(text)
   expect(page).to have_content(text)
 end
 
-def sign_up(email:, password:)
+def sign_up(email:, username:, password:)
   visit '/users/sign_up'
   fill_in 'Email', with: email
+  fill_in 'Username', with: username
   fill_in 'Password', with: password
   fill_in 'Password confirmation', with: password
   click_button 'Sign up'

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -2,7 +2,7 @@ module ControllerMacros
   def login_user
     before(:each) do
       @request.env["devise.mapping"] = Devise.mappings[:user]
-      user = User.new(:email => 'test@example.com', :password => 'password', :password_confirmation => 'password')
+      user = User.new(:email => 'test@example.com', :username => 'Troy', :password => 'password', :password_confirmation => 'password')
       user.save
       sign_in user
     end


### PR DESCRIPTION
We've done a lot, originally added a profile link but changed it to a more appropriate settings link.
Added usernames to our database, posts, sign in/sign up.

Example:  Email: Salarsweatsuit@sweatsuit.com 
                 Username: Salarssweatsuit 

Changed a small bit of CSS to get the usernames and the date of the post on the same line.
Added many edge case error messages:
 - Username can't be left blank 
 - Username is invalid (when using special characters)
 - Username already exists